### PR TITLE
Fix blank screen by restoring script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <!-- Vite will auto-inject built scripts here during npm run build -->
+    <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restore Vite entry script in `index.html`

## Testing
- `npm run build` *(fails: esbuild for another platform)*

------
https://chatgpt.com/codex/tasks/task_e_686ab7be2ec0832babce5e03cb6cfa06