### PR TITLE
Fix object rendering in AIChat

### DIFF
--- a/src/AIChat.jsx
+++ b/src/AIChat.jsx
@@ -71,7 +71,10 @@ function AIChat() {
       setMessages((prev) => [
         ...prev,
         { role: "assistant", content: reply },
-        ...cards.map((c) => ({ role: "assistant", content: c })),
+        ...cards.map((c) => ({
+          role: "assistant",
+          content: typeof c === "string" ? c : JSON.stringify(c),
+        })),
         { role: "assistant", content: suggestionBlock }
       ]);
       speak(reply);


### PR DESCRIPTION
## Summary
- stringify AI chat card objects before rendering to ReactMarkdown

## Testing
- `node node_modules/vite/bin/vite.js build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686acdf7177c832bac726261f939166c