### PR TITLE
Add Droxion logo and iOS app icon branding

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-label="Droxion logo">
+  <defs>
+    <linearGradient id="droxionGradient" x1="0.15" y1="0.95" x2="0.9" y2="0.08">
+      <stop offset="0" stop-color="#12d8ff"/>
+      <stop offset="0.32" stop-color="#4169ff"/>
+      <stop offset="0.62" stop-color="#9a2cff"/>
+      <stop offset="1" stop-color="#ff3fbd"/>
+    </linearGradient>
+    <linearGradient id="foldGradient" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0" stop-color="#12d8ff"/>
+      <stop offset="0.45" stop-color="#3a54ff"/>
+      <stop offset="1" stop-color="#8a22ff"/>
+    </linearGradient>
+    <radialGradient id="backgroundGlow" cx="50%" cy="45%" r="70%">
+      <stop offset="0" stop-color="#1b0b44"/>
+      <stop offset="0.58" stop-color="#0d0824"/>
+      <stop offset="1" stop-color="#05050c"/>
+    </radialGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="14" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="1024" height="1024" rx="190" fill="url(#backgroundGlow)"/>
+  <circle cx="720" cy="300" r="250" fill="#b81cff" opacity="0.07"/>
+  <circle cx="300" cy="760" r="220" fill="#008cff" opacity="0.08"/>
+  <g filter="url(#softGlow)">
+    <path fill="url(#droxionGradient)" fill-rule="evenodd" d="M252 176h294c201 0 326 143 326 336S747 848 546 848H252V176Zm202 181v310h92c99 0 157-61 157-155s-58-155-157-155h-92Z"/>
+    <path d="M252 176 454 356v311L252 848V176Z" fill="url(#foldGradient)" opacity="0.98"/>
+    <path d="M252 176 454 356" fill="none" stroke="#ffd6ff" stroke-width="12" stroke-linecap="round" opacity="0.55"/>
+    <path d="M252 848 454 667" fill="none" stroke="#8defff" stroke-width="11" stroke-linecap="round" opacity="0.55"/>
+    <path fill="none" stroke="#ffffff" stroke-opacity="0.42" stroke-width="6" d="M252 176h294c201 0 326 143 326 336S747 848 546 848H252"/>
+  </g>
+</svg>

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -49,7 +49,7 @@ workflows:
       - name: Install Capacitor tooling for CI
         script: |
           set -e
-          npm install --no-save @capacitor/cli@7 @capacitor/core@7 @capacitor/ios@7
+          npm install --no-save @capacitor/cli@7 @capacitor/core@7 @capacitor/ios@7 @capacitor/assets@3.0.5
 
       - name: Create or sync native iOS project
         script: |
@@ -58,6 +58,16 @@ workflows:
             npx cap add ios
           fi
           npx cap sync ios
+
+      - name: Generate Droxion iOS branding
+        script: |
+          set -e
+          npx @capacitor/assets generate --ios \
+            --assetPath assets \
+            --iconBackgroundColor '#08080c' \
+            --iconBackgroundColorDark '#08080c' \
+            --splashBackgroundColor '#08080c' \
+            --splashBackgroundColorDark '#08080c'
 
       - name: Configure iOS privacy permissions
         script: |

--- a/index.html
+++ b/index.html
@@ -3,7 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <title>Droxion</title>
+    <meta name="theme-color" content="#08080c">
+    <meta name="apple-mobile-web-app-title" content="Droxion Live">
+    <meta name="application-name" content="Droxion Live">
+    <link rel="icon" type="image/svg+xml" href="/droxion-logo.svg">
+    <link rel="apple-touch-icon" href="/droxion-logo.svg">
+    <title>Droxion Live</title>
   </head>
   <body>
     <div id="root"></div>

--- a/public/droxion-logo.svg
+++ b/public/droxion-logo.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1024 1024" role="img" aria-label="Droxion logo">
+  <defs>
+    <linearGradient id="droxionGradient" x1="0.15" y1="0.95" x2="0.9" y2="0.08">
+      <stop offset="0" stop-color="#12d8ff"/>
+      <stop offset="0.32" stop-color="#4169ff"/>
+      <stop offset="0.62" stop-color="#9a2cff"/>
+      <stop offset="1" stop-color="#ff3fbd"/>
+    </linearGradient>
+    <linearGradient id="foldGradient" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0" stop-color="#12d8ff"/>
+      <stop offset="0.45" stop-color="#3a54ff"/>
+      <stop offset="1" stop-color="#8a22ff"/>
+    </linearGradient>
+    <radialGradient id="backgroundGlow" cx="50%" cy="45%" r="70%">
+      <stop offset="0" stop-color="#1b0b44"/>
+      <stop offset="0.58" stop-color="#0d0824"/>
+      <stop offset="1" stop-color="#05050c"/>
+    </radialGradient>
+    <filter id="softGlow" x="-25%" y="-25%" width="150%" height="150%">
+      <feGaussianBlur stdDeviation="14" result="blur"/>
+      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+  <rect width="1024" height="1024" rx="190" fill="url(#backgroundGlow)"/>
+  <circle cx="720" cy="300" r="250" fill="#b81cff" opacity="0.07"/>
+  <circle cx="300" cy="760" r="220" fill="#008cff" opacity="0.08"/>
+  <g filter="url(#softGlow)">
+    <path fill="url(#droxionGradient)" fill-rule="evenodd" d="M252 176h294c201 0 326 143 326 336S747 848 546 848H252V176Zm202 181v310h92c99 0 157-61 157-155s-58-155-157-155h-92Z"/>
+    <path d="M252 176 454 356v311L252 848V176Z" fill="url(#foldGradient)" opacity="0.98"/>
+    <path d="M252 176 454 356" fill="none" stroke="#ffd6ff" stroke-width="12" stroke-linecap="round" opacity="0.55"/>
+    <path d="M252 848 454 667" fill="none" stroke="#8defff" stroke-width="11" stroke-linecap="round" opacity="0.55"/>
+    <path fill="none" stroke="#ffffff" stroke-opacity="0.42" stroke-width="6" d="M252 176h294c201 0 326 143 326 336S747 848 546 848H252"/>
+  </g>
+</svg>

--- a/src/LiveFirstApp.jsx
+++ b/src/LiveFirstApp.jsx
@@ -96,7 +96,7 @@ export default function LiveFirstApp() {
 
   return (
     <main className={`lfShell ${immersiveLive ? 'lfImmersiveLive' : ''}`}>
-      {!immersiveLive && <header className="lfTopbar"><button className="lfBrand" type="button" onClick={() => setTab('live')} aria-label="Open Droxion home"><span className="lfBrandMark">D</span><span><strong>DROXION</strong><small>LIVE SOCIAL</small></span></button><button className="lfCoins" type="button" onClick={() => setWalletOpen(true)}><Coins size={17} /> {coins}</button></header>}
+      {!immersiveLive && <header className="lfTopbar"><button className="lfBrand" type="button" onClick={() => setTab('live')} aria-label="Open Droxion home"><img className="lfBrandMark" src="/droxion-logo.svg" alt="" aria-hidden="true" /><span><strong>DROXION</strong><small>LIVE SOCIAL</small></span></button><button className="lfCoins" type="button" onClick={() => setWalletOpen(true)}><Coins size={17} /> {coins}</button></header>}
 
       <div className={`lfContent ${immersiveLive ? 'lfContentImmersive' : ''}`}>{content}</div>
 

--- a/src/responsive-overrides.css
+++ b/src/responsive-overrides.css
@@ -106,3 +106,18 @@
   .liveTopV4{top:max(calc(env(safe-area-inset-top) + 6px),18px)!important}
   .liveRoomV4 .liveGuestVideo{top:max(calc(env(safe-area-inset-top) + 58px),70px)!important}
 }
+
+/* Droxion brand mark */
+.lfBrandMark{
+  width:38px!important;
+  height:38px!important;
+  flex:0 0 38px!important;
+  display:block!important;
+  border-radius:12px!important;
+  object-fit:cover!important;
+  background:#090713!important;
+  box-shadow:0 8px 26px rgba(98,55,255,.34)!important;
+}
+@media(max-width:420px){
+  .lfBrandMark{width:34px!important;height:34px!important;flex-basis:34px!important;border-radius:10px!important}
+}


### PR DESCRIPTION
Apply the approved Droxion neon D branding across the app.

- Add vector Droxion logo source
- Use logo in the app header
- Add favicon/app metadata
- Generate iOS app icon and splash assets automatically in Codemagic from the logo
- Keep existing LIVE functionality unchanged