### PR TITLE
Add Apple In-App Purchase for Droxion Coins

### DIFF
--- a/APPLE_IAP_SETUP.md
+++ b/APPLE_IAP_SETUP.md
@@ -1,0 +1,36 @@
+# Droxion Live — Apple In-App Purchase setup
+
+Bundle ID: `com.droxion.live`
+
+Create these four **Consumable** In-App Purchases in App Store Connect. Product IDs are permanent, so use them exactly as written.
+
+| Droxion pack | Apple Product ID | Intended US price |
+|---|---|---:|
+| 100 Coins | `com.droxion.live.coins100` | $1.99 |
+| 550 Coins | `com.droxion.live.coins550` | $7.99 |
+| 1,200 Coins | `com.droxion.live.coins1200` | $14.99 |
+| 3,000 Coins | `com.droxion.live.coins3000` | $29.99 |
+
+For each product:
+
+1. App Store Connect → Droxion Live → Monetization → In-App Purchases.
+2. Create a new **Consumable**.
+3. Use the exact Product ID above.
+4. Add English (U.S.) localization with the pack name and a short description such as `Droxion Coins for LIVE virtual gifts.`
+5. Choose the matching price point for the intended US price.
+6. Add the required review screenshot after the new TestFlight build shows the wallet purchase screen.
+7. Leave the product available for sale and submit the IAP with the app version when the final build is ready.
+
+## App implementation
+
+- iOS uses StoreKit 2 through `@capgo/native-purchases`.
+- Prices shown in the iPhone wallet come from Apple StoreKit, not hardcoded app prices.
+- The authenticated Supabase user UUID is passed as StoreKit `appAccountToken`.
+- The client does not grant coins by itself.
+- `/api/apple/verify-purchase` validates the Apple receipt, bundle ID, product ID and transaction ID before server-side fulfillment.
+- `droxion_apple_transactions.transaction_id` is unique, so the same Apple transaction cannot credit coins twice.
+- The database maps Apple Product IDs to the existing Droxion coin packs and grants the server-configured coin amount.
+
+## Sandbox test
+
+Create an App Store Connect Sandbox Tester, install the latest TestFlight build, open Droxion Wallet, purchase a small coin pack, confirm the coin balance increases once, then use those coins to send a LIVE gift.

--- a/api/apple/verify-purchase.js
+++ b/api/apple/verify-purchase.js
@@ -1,0 +1,138 @@
+import { callRpc, getSupabaseConfig, getSupabaseHeaders, getSupabaseUser, readJsonBody } from '../paypal/lib.js';
+
+const BUNDLE_ID = 'com.droxion.live';
+const APPLE_PRODUCTION_VERIFY_URL = 'https://buy.itunes.apple.com/verifyReceipt';
+const APPLE_SANDBOX_VERIFY_URL = 'https://sandbox.itunes.apple.com/verifyReceipt';
+
+async function verifyReceiptAt(url, receipt) {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ 'receipt-data': receipt, 'exclude-old-transactions': false })
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error('Apple receipt verification request failed.');
+  return payload;
+}
+
+async function verifyAppleReceipt(receipt) {
+  let payload = await verifyReceiptAt(APPLE_PRODUCTION_VERIFY_URL, receipt);
+  let environment = 'Production';
+
+  if (Number(payload?.status) === 21007) {
+    payload = await verifyReceiptAt(APPLE_SANDBOX_VERIFY_URL, receipt);
+    environment = 'Sandbox';
+  }
+
+  if (Number(payload?.status) !== 0) {
+    throw new Error(`Apple could not verify this purchase (status ${payload?.status ?? 'unknown'}).`);
+  }
+
+  return { payload, environment };
+}
+
+async function findCoinProductByAppleId(appleProductId) {
+  const { supabaseUrl } = getSupabaseConfig();
+  const response = await fetch(
+    `${supabaseUrl}/rest/v1/droxion_products?select=id,product_type,name,coins_granted,active,apple_product_id&active=eq.true&product_type=eq.coin_pack&apple_product_id=eq.${encodeURIComponent(appleProductId)}`,
+    { headers: getSupabaseHeaders(null, true) }
+  );
+  const data = await response.json().catch(() => []);
+  if (!response.ok) throw new Error('Unable to load the Droxion coin package.');
+  return Array.isArray(data) && data.length ? data[0] : null;
+}
+
+function receiptTransactions(payload) {
+  const receiptItems = Array.isArray(payload?.receipt?.in_app) ? payload.receipt.in_app : [];
+  const latestItems = Array.isArray(payload?.latest_receipt_info) ? payload.latest_receipt_info : [];
+  return [...receiptItems, ...latestItems];
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    res.status(405).json({ error: 'Method not allowed.' });
+    return;
+  }
+
+  try {
+    const authHeader = req.headers.authorization || '';
+    const accessToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+    const user = await getSupabaseUser(accessToken);
+    const body = await readJsonBody(req);
+
+    const receipt = typeof body?.receipt === 'string' ? body.receipt.trim() : '';
+    const transactionId = typeof body?.transactionId === 'string' ? body.transactionId.trim() : '';
+    const productId = typeof body?.productId === 'string' ? body.productId.trim() : '';
+
+    if (!receipt || !transactionId || !productId) {
+      res.status(400).json({ error: 'Apple receipt, transaction ID and product ID are required.' });
+      return;
+    }
+
+    const product = await findCoinProductByAppleId(productId);
+    if (!product || Number(product.coins_granted) <= 0) {
+      res.status(400).json({ error: 'This Apple product is not an active Droxion coin package.' });
+      return;
+    }
+
+    const { payload, environment } = await verifyAppleReceipt(receipt);
+    if (payload?.receipt?.bundle_id !== BUNDLE_ID) {
+      res.status(400).json({ error: 'Apple receipt bundle does not match Droxion Live.' });
+      return;
+    }
+
+    const transaction = receiptTransactions(payload).find(item =>
+      String(item?.transaction_id || '') === transactionId &&
+      String(item?.product_id || '') === productId
+    );
+
+    if (!transaction) {
+      res.status(400).json({ error: 'The verified Apple receipt does not contain this transaction.' });
+      return;
+    }
+
+    if (transaction?.cancellation_date || transaction?.cancellation_date_ms) {
+      res.status(400).json({ error: 'This Apple purchase was cancelled or refunded.' });
+      return;
+    }
+
+    const appAccountToken = String(transaction?.app_account_token || transaction?.appAccountToken || '').trim();
+    if (appAccountToken && appAccountToken.toLowerCase() !== String(user.id).toLowerCase()) {
+      res.status(403).json({ error: 'This Apple purchase belongs to a different Droxion account.' });
+      return;
+    }
+
+    const purchaseDateMs = Number(transaction?.purchase_date_ms || 0);
+    const purchaseDate = purchaseDateMs > 0 ? new Date(purchaseDateMs).toISOString() : null;
+
+    const result = await callRpc(null, 'droxion_fulfill_apple_purchase', {
+      p_user_id: user.id,
+      p_transaction_id: transactionId,
+      p_product_id: productId,
+      p_package_id: product.id,
+      p_coins: Number(product.coins_granted),
+      p_environment: environment,
+      p_purchase_date: purchaseDate,
+      p_raw_payload: {
+        transaction_id: transactionId,
+        product_id: productId,
+        purchase_date_ms: transaction?.purchase_date_ms || null,
+        original_transaction_id: transaction?.original_transaction_id || null,
+        app_account_token: appAccountToken || null
+      }
+    });
+
+    res.status(200).json({
+      ok: true,
+      alreadyCompleted: Boolean(result?.already_completed),
+      coinsGranted: Number(result?.coins || product.coins_granted),
+      coinBalance: Number(result?.coin_balance || 0),
+      transactionId,
+      productId,
+      environment
+    });
+  } catch (error) {
+    res.status(502).json({ error: error?.message || 'Apple purchase verification failed.' });
+  }
+}

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -33,13 +33,13 @@ workflows:
         - $HOME/Library/Developer/Xcode/DerivedData
 
     scripts:
-      - name: Install web dependencies
+      - name: Install web and StoreKit dependencies
         script: |
           set -e
           npm config set audit false
           npm config set fund false
           npm config set progress false
-          npm ci
+          npm install --no-audit --no-fund
 
       - name: Build Droxion web bundle
         script: |
@@ -49,7 +49,7 @@ workflows:
       - name: Install Capacitor tooling for CI
         script: |
           set -e
-          npm install --no-save @capacitor/cli@7 @capacitor/core@7 @capacitor/ios@7 @capacitor/assets@3.0.5
+          npm install --no-save @capacitor/cli@7 @capacitor/ios@7 @capacitor/assets@3.0.5
 
       - name: Create or sync native iOS project
         script: |

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "preview": "vite preview --port 4173"
   },
   "dependencies": {
+    "@apple/app-store-server-library": "^3.1.0",
+    "@capgo/native-purchases": "^7.16.0",
+    "@capacitor/core": "^7.0.0",
     "@supabase/supabase-js": "^2.57.4",
     "@vercel/analytics": "^1.3.1",
     "@vitejs/plugin-react": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview --port 4173"
   },
   "dependencies": {
-    "@apple/app-store-server-library": "^3.1.0",
     "@capgo/native-purchases": "^7.16.0",
     "@capacitor/core": "^7.0.0",
     "@supabase/supabase-js": "^2.57.4",

--- a/src/DroxionWallet.jsx
+++ b/src/DroxionWallet.jsx
@@ -1,20 +1,27 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Capacitor } from '@capacitor/core';
+import { NativePurchases, PURCHASE_TYPE } from '@capgo/native-purchases';
 import { Coins, X } from 'lucide-react';
 import { supabase } from './supabaseClient';
 
 function getNativeStorePlatform() {
-  if (typeof window === 'undefined') return '';
   try {
-    const platform = window.Capacitor?.getPlatform?.();
+    const platform = Capacitor.getPlatform?.();
     if (platform === 'ios' || platform === 'android') return platform;
-    if (window.Capacitor?.isNativePlatform?.()) return platform || 'native';
+    if (Capacitor.isNativePlatform?.()) return platform || 'native';
   } catch {}
   return '';
 }
 
+function storeProductKey(product) {
+  return product?.identifier || product?.productIdentifier || '';
+}
+
 export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free', onClose, onBalanceRefresh }) {
   const [products, setProducts] = useState([]);
+  const [appleProducts, setAppleProducts] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [storeLoading, setStoreLoading] = useState(false);
   const [checkoutId, setCheckoutId] = useState('');
   const [selectedProduct, setSelectedProduct] = useState(null);
   const [paypalOrderId, setPaypalOrderId] = useState('');
@@ -24,13 +31,14 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
   const paypalRef = useRef(null);
   const nativeStorePlatform = getNativeStorePlatform();
   const nativeMobile = Boolean(nativeStorePlatform);
+  const isIOS = nativeStorePlatform === 'ios';
 
   useEffect(() => {
     let alive = true;
     (async () => {
       const { data, error: queryError } = await supabase
         .from('droxion_products')
-        .select('id,product_type,name,price_cents,coins_granted,plan,sort_order')
+        .select('id,product_type,name,price_cents,coins_granted,plan,sort_order,apple_product_id')
         .eq('active', true)
         .order('sort_order');
       if (!alive) return;
@@ -41,15 +49,115 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
     return () => { alive = false; };
   }, []);
 
-  const price = cents => `$${(Number(cents || 0) / 100).toFixed(2)}`;
   const coinProducts = products.filter(product => product.product_type === 'coin_pack');
   const plans = products.filter(product => product.product_type === 'subscription');
+  const appleProductMap = useMemo(() => {
+    const map = new Map();
+    appleProducts.forEach(product => {
+      const key = storeProductKey(product);
+      if (key) map.set(key, product);
+    });
+    return map;
+  }, [appleProducts]);
+
+  useEffect(() => {
+    if (!isIOS || loading || !coinProducts.length) return;
+    let alive = true;
+    (async () => {
+      setStoreLoading(true);
+      try {
+        const { isBillingSupported } = await NativePurchases.isBillingSupported();
+        if (!isBillingSupported) throw new Error('Apple In-App Purchase is not available on this device.');
+        const ids = coinProducts.map(product => product.apple_product_id).filter(Boolean);
+        if (!ids.length) throw new Error('Droxion coin products are not configured for the App Store.');
+        const { products: storeProducts } = await NativePurchases.getProducts({
+          productIdentifiers: ids,
+          productType: PURCHASE_TYPE.INAPP
+        });
+        if (alive) setAppleProducts(storeProducts || []);
+      } catch (err) {
+        if (alive) setError(err?.message || 'Could not load Apple coin products.');
+      } finally {
+        if (alive) setStoreLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [isIOS, loading, products]);
+
+  const webPrice = cents => `$${(Number(cents || 0) / 100).toFixed(2)}`;
+
+  async function verifyAppleTransaction(transaction, expectedProductId) {
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token || !session?.user?.id) throw new Error('Please sign in again before buying coins.');
+    if (!transaction?.transactionId || !transaction?.receipt) throw new Error('Apple did not return a verifiable purchase receipt.');
+
+    const response = await fetch('/api/apple/verify-purchase', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session.access_token}`
+      },
+      body: JSON.stringify({
+        receipt: transaction.receipt,
+        transactionId: transaction.transactionId,
+        productId: expectedProductId
+      })
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok || !payload?.ok) throw new Error(payload?.error || 'Apple purchase verification failed.');
+
+    try {
+      await NativePurchases.acknowledgePurchase({ purchaseToken: transaction.transactionId });
+    } catch (ackError) {
+      console.warn('StoreKit finish retry needed', ackError);
+    }
+
+    await onBalanceRefresh?.();
+    return payload;
+  }
+
+  async function buyAppleCoins(product) {
+    if (checkoutId) return;
+    const productId = product.apple_product_id;
+    const storeProduct = appleProductMap.get(productId);
+    if (!productId || !storeProduct) {
+      setError('This coin pack is not available from Apple yet.');
+      return;
+    }
+
+    setError('');
+    setSuccess('');
+    setCheckoutId(product.id);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.user?.id) throw new Error('Please sign in again before buying coins.');
+
+      const transaction = await NativePurchases.purchaseProduct({
+        productIdentifier: productId,
+        productType: PURCHASE_TYPE.INAPP,
+        quantity: 1,
+        appAccountToken: session.user.id,
+        isConsumable: true,
+        autoAcknowledgePurchases: false
+      });
+
+      const result = await verifyAppleTransaction(transaction, productId);
+      setSuccess(`${result.coinsGranted || product.coins_granted} coins added to your Droxion wallet.`);
+    } catch (err) {
+      const message = String(err?.message || 'Apple purchase was not completed.');
+      if (!/cancel/i.test(message)) setError(message);
+    } finally {
+      setCheckoutId('');
+    }
+  }
 
   async function buyCoins(product) {
+    if (isIOS) {
+      await buyAppleCoins(product);
+      return;
+    }
     if (nativeMobile) {
-      setError(nativeStorePlatform === 'ios'
-        ? 'Coin purchases on iPhone must use Apple In-App Purchase. Store products are being connected for release.'
-        : 'Coin purchases on Android must use Google Play Billing. Store products are being connected for release.');
+      setError('Coin purchases on Android will use Google Play Billing in the Android release.');
       return;
     }
     if (checkoutId) return;
@@ -173,38 +281,43 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
         {success && <div className="walletSuccess">{success}</div>}
 
         <h3>Buy Coins</h3>
-        {nativeMobile ? (
-          <div className="publishBillingNotice">
-            {nativeStorePlatform === 'ios'
-              ? 'Apple In-App Purchase is required for coin purchases on iPhone. Purchases are disabled until the App Store coin products are connected.'
-              : 'Google Play Billing is required for coin purchases on Android. Purchases are disabled until the Play Store coin products are connected.'}
-          </div>
-        ) : loading ? <p className="walletMuted">Loading…</p> : (
+        {loading || (isIOS && storeLoading) ? <p className="walletMuted">Loading store…</p> : nativeStorePlatform === 'android' ? (
+          <div className="publishBillingNotice">Google Play Billing will be enabled in the Android release.</div>
+        ) : (
           <div className="walletGrid">
-            {coinProducts.map(product => (
-              <button key={product.id} disabled={Boolean(checkoutId)} onClick={() => buyCoins(product)}>
-                <Coins size={22} />
-                <strong>{product.coins_granted} coins</strong>
-                <span>{checkoutId === product.id ? 'Opening PayPal…' : price(product.price_cents)}</span>
-              </button>
-            ))}
+            {coinProducts.map(product => {
+              const storeProduct = isIOS ? appleProductMap.get(product.apple_product_id) : null;
+              const displayPrice = isIOS ? (storeProduct?.priceString || 'Unavailable') : webPrice(product.price_cents);
+              const unavailable = isIOS && !storeProduct;
+              return (
+                <button key={product.id} disabled={Boolean(checkoutId) || unavailable} onClick={() => buyCoins(product)}>
+                  <Coins size={22} />
+                  <strong>{product.coins_granted} coins</strong>
+                  <span>{checkoutId === product.id ? (isIOS ? 'Purchasing…' : 'Opening PayPal…') : displayPrice}</span>
+                </button>
+              );
+            })}
           </div>
         )}
 
-        <h3>Droxion Plans</h3>
-        <div className="walletPlans">
-          {plans.length === 0 && !loading && <p className="walletMuted">No active plans are available right now.</p>}
-          {plans.map(product => (
-            <div className="walletPlan" key={product.id}>
-              <div>
-                <strong>{product.name}</strong>
-                <span>{price(product.price_cents)}/month</span>
-              </div>
-              <small>+{product.coins_granted || 0} coins</small>
-              <button type="button" disabled title="Subscription checkout will be enabled after store billing setup is complete">Coming soon</button>
+        {!nativeMobile && (
+          <>
+            <h3>Droxion Plans</h3>
+            <div className="walletPlans">
+              {plans.length === 0 && !loading && <p className="walletMuted">No active plans are available right now.</p>}
+              {plans.map(product => (
+                <div className="walletPlan" key={product.id}>
+                  <div>
+                    <strong>{product.name}</strong>
+                    <span>{webPrice(product.price_cents)}/month</span>
+                  </div>
+                  <small>+{product.coins_granted || 0} coins</small>
+                  <button type="button" disabled title="Subscription checkout will be enabled after store billing setup is complete">Coming soon</button>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          </>
+        )}
 
         {!nativeMobile && selectedProduct && paypalOrderId && (
           <div className="paypalBox">

--- a/src/PublishReadyEnhancer.jsx
+++ b/src/PublishReadyEnhancer.jsx
@@ -75,7 +75,7 @@ export default function PublishReadyEnhancer() {
 
     function addNativePaymentGuard() {
       const platform = nativePlatform();
-      if (!platform) return;
+      if (platform !== 'android') return;
 
       document.querySelectorAll('.liveBuyCoinsV4').forEach(button => {
         button.style.display = 'none';
@@ -91,9 +91,7 @@ export default function PublishReadyEnhancer() {
       if (heading) {
         const note = document.createElement('div');
         note.className = 'publishBillingNotice';
-        note.textContent = platform === 'ios'
-          ? 'Coin purchases use Apple In-App Purchase on iPhone. Store products are being connected for the App Store release.'
-          : 'Coin purchases use Google Play Billing on Android. Store products are being connected for the Play Store release.';
+        note.textContent = 'Coin purchases use Google Play Billing on Android. Store products will be connected for the Play Store release.';
         heading.insertAdjacentElement('afterend', note);
       }
     }


### PR DESCRIPTION
Connect Droxion's four consumable coin packs to Apple StoreKit 2 for iPhone.

- Add Capacitor 7 native purchases / StoreKit 2 integration
- Map 100 / 550 / 1200 / 3000 coin packs to permanent Apple Product IDs
- Show Apple-localized StoreKit prices on iPhone instead of hardcoded prices
- Purchase consumable coins with the authenticated Droxion user UUID as appAccountToken
- Verify Apple receipts server-side before granting coins
- Add idempotent Apple transaction ledger and atomic wallet crediting
- Finish the StoreKit transaction only after server fulfillment
- Keep PayPal web-only and Android external checkout disabled
- Update Codemagic so the StoreKit plugin is installed and synced into the generated iOS project
- Add App Store Connect IAP setup guide

Apple products still need to be created in App Store Connect with the exact IDs documented in APPLE_IAP_SETUP.md before purchases will appear on device.