### PR TITLE
Fix iOS StoreKit pod deployment target

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -40,6 +40,8 @@ workflows:
           npm config set fund false
           npm config set progress false
           npm install --no-audit --no-fund
+          npm install --no-save --no-audit --no-fund @capgo/native-purchases@7.16.0
+          node -e "const p=require('./node_modules/@capgo/native-purchases/package.json'); if(p.version!=='7.16.0') throw new Error('Expected native-purchases 7.16.0, got '+p.version); console.log('Using @capgo/native-purchases '+p.version)"
 
       - name: Build Droxion web bundle
         script: |

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview --port 4173"
   },
   "dependencies": {
-    "@capgo/native-purchases": "^7.16.0",
+    "@capgo/native-purchases": "7.16.0",
     "@capacitor/core": "^7.0.0",
     "@supabase/supabase-js": "^2.57.4",
     "@vercel/analytics": "^1.3.1",


### PR DESCRIPTION
Fix Codemagic iOS dependency resolution for Apple IAP.

- Pin @capgo/native-purchases to exactly 7.16.0
- Force Codemagic to install exactly 7.16.0 and verify the installed version
- Avoid newer 7.x releases whose CocoaPod requires a higher iOS deployment target than the generated project

The failed Codemagic log showed CapgoNativePurchases was rejected for requiring a higher minimum deployment target. Version 7.16.0 is compatible with iOS 14+, while the newer pod raised its requirement.