### PR TITLE
Fix Apple IAP StoreKit 2 verification

### DIFF
--- a/api/apple/verify-purchase.js
+++ b/api/apple/verify-purchase.js
@@ -1,8 +1,80 @@
+import { X509Certificate, verify as verifySignature } from 'node:crypto';
 import { callRpc, getSupabaseConfig, getSupabaseHeaders, getSupabaseUser, readJsonBody } from '../paypal/lib.js';
 
 const BUNDLE_ID = 'com.droxion.live';
 const APPLE_PRODUCTION_VERIFY_URL = 'https://buy.itunes.apple.com/verifyReceipt';
 const APPLE_SANDBOX_VERIFY_URL = 'https://sandbox.itunes.apple.com/verifyReceipt';
+
+// Apple publishes these trusted root SHA-256 fingerprints in its root store documentation.
+const APPLE_ROOT_SHA256 = new Set([
+  'C2B9B042DD57830E7D117DAC55AC8AE19407D38E41D88F3215BC3A890444A050', // Apple Root CA - G2
+  '63343ABFB89A6A03EBB57E9B3F5FA7BE7C4F5C756F3017B3A8C488C3653E9179', // Apple Root CA - G3
+  'B0B1730ECBC7FF4505142C49F1295E6EDA6BCAED7E2C68C5BE91B5A11001F024' // Apple Root CA
+]);
+
+function base64UrlBuffer(value) {
+  const normalized = String(value || '').replace(/-/g, '+').replace(/_/g, '/');
+  const padding = normalized.length % 4 ? '='.repeat(4 - (normalized.length % 4)) : '';
+  return Buffer.from(normalized + padding, 'base64');
+}
+
+function parseJsonPart(value, label) {
+  try {
+    return JSON.parse(base64UrlBuffer(value).toString('utf8'));
+  } catch {
+    throw new Error(`Apple ${label} is malformed.`);
+  }
+}
+
+function normalizedFingerprint(cert) {
+  return String(cert.fingerprint256 || '').replace(/:/g, '').toUpperCase();
+}
+
+function certIsCurrentlyValid(cert) {
+  const now = Date.now();
+  const start = Date.parse(cert.validFrom);
+  const end = Date.parse(cert.validTo);
+  return Number.isFinite(start) && Number.isFinite(end) && now >= start && now <= end;
+}
+
+function verifyStoreKitJws(jws) {
+  const parts = String(jws || '').split('.');
+  if (parts.length !== 3) throw new Error('Apple signed transaction is malformed.');
+
+  const [encodedHeader, encodedPayload, encodedSignature] = parts;
+  const header = parseJsonPart(encodedHeader, 'JWS header');
+  if (header?.alg !== 'ES256' || !Array.isArray(header?.x5c) || header.x5c.length < 2) {
+    throw new Error('Apple signed transaction certificate chain is invalid.');
+  }
+
+  const certs = header.x5c.map(value => new X509Certificate(Buffer.from(value, 'base64')));
+  for (const cert of certs) {
+    if (!certIsCurrentlyValid(cert)) throw new Error('Apple signed transaction certificate is expired or not yet valid.');
+  }
+
+  for (let index = 0; index < certs.length - 1; index += 1) {
+    if (!certs[index].verify(certs[index + 1].publicKey)) {
+      throw new Error('Apple signed transaction certificate chain could not be verified.');
+    }
+  }
+
+  const root = certs[certs.length - 1];
+  if (!APPLE_ROOT_SHA256.has(normalizedFingerprint(root))) {
+    throw new Error('Apple signed transaction did not chain to a trusted Apple root.');
+  }
+
+  const signedData = Buffer.from(`${encodedHeader}.${encodedPayload}`);
+  const signature = base64UrlBuffer(encodedSignature);
+  const validSignature = verifySignature(
+    'sha256',
+    signedData,
+    { key: certs[0].publicKey, dsaEncoding: 'ieee-p1363' },
+    signature
+  );
+  if (!validSignature) throw new Error('Apple signed transaction signature is invalid.');
+
+  return parseJsonPart(encodedPayload, 'signed transaction payload');
+}
 
 async function verifyReceiptAt(url, receipt) {
   const response = await fetch(url, {
@@ -48,6 +120,19 @@ function receiptTransactions(payload) {
   return [...receiptItems, ...latestItems];
 }
 
+function normalizeSignedTransaction(payload) {
+  return {
+    transactionId: String(payload?.transactionId || ''),
+    productId: String(payload?.productId || ''),
+    bundleId: String(payload?.bundleId || ''),
+    appAccountToken: String(payload?.appAccountToken || ''),
+    environment: String(payload?.environment || 'Production'),
+    purchaseDateMs: Number(payload?.purchaseDate || 0),
+    originalTransactionId: String(payload?.originalTransactionId || ''),
+    revoked: Boolean(payload?.revocationDate || payload?.revocationReason)
+  };
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', 'POST');
@@ -62,11 +147,12 @@ export default async function handler(req, res) {
     const body = await readJsonBody(req);
 
     const receipt = typeof body?.receipt === 'string' ? body.receipt.trim() : '';
+    const jwsRepresentation = typeof body?.jwsRepresentation === 'string' ? body.jwsRepresentation.trim() : '';
     const transactionId = typeof body?.transactionId === 'string' ? body.transactionId.trim() : '';
     const productId = typeof body?.productId === 'string' ? body.productId.trim() : '';
 
-    if (!receipt || !transactionId || !productId) {
-      res.status(400).json({ error: 'Apple receipt, transaction ID and product ID are required.' });
+    if ((!receipt && !jwsRepresentation) || !transactionId || !productId) {
+      res.status(400).json({ error: 'Apple signed transaction or receipt, transaction ID and product ID are required.' });
       return;
     }
 
@@ -76,35 +162,61 @@ export default async function handler(req, res) {
       return;
     }
 
-    const { payload, environment } = await verifyAppleReceipt(receipt);
-    if (payload?.receipt?.bundle_id !== BUNDLE_ID) {
-      res.status(400).json({ error: 'Apple receipt bundle does not match Droxion Live.' });
-      return;
+    let environment = 'Production';
+    let purchaseDate = null;
+    let originalTransactionId = null;
+    let appAccountToken = '';
+
+    if (jwsRepresentation) {
+      const signed = normalizeSignedTransaction(verifyStoreKitJws(jwsRepresentation));
+      if (signed.bundleId !== BUNDLE_ID) {
+        res.status(400).json({ error: 'Apple signed transaction bundle does not match Droxion Live.' });
+        return;
+      }
+      if (signed.transactionId !== transactionId || signed.productId !== productId) {
+        res.status(400).json({ error: 'Apple signed transaction does not match this purchase.' });
+        return;
+      }
+      if (signed.revoked) {
+        res.status(400).json({ error: 'This Apple purchase was revoked or refunded.' });
+        return;
+      }
+      appAccountToken = signed.appAccountToken;
+      environment = signed.environment || 'Production';
+      originalTransactionId = signed.originalTransactionId || null;
+      purchaseDate = signed.purchaseDateMs > 0 ? new Date(signed.purchaseDateMs).toISOString() : null;
+    } else {
+      const { payload, environment: receiptEnvironment } = await verifyAppleReceipt(receipt);
+      environment = receiptEnvironment;
+      if (payload?.receipt?.bundle_id !== BUNDLE_ID) {
+        res.status(400).json({ error: 'Apple receipt bundle does not match Droxion Live.' });
+        return;
+      }
+
+      const transaction = receiptTransactions(payload).find(item =>
+        String(item?.transaction_id || '') === transactionId &&
+        String(item?.product_id || '') === productId
+      );
+
+      if (!transaction) {
+        res.status(400).json({ error: 'The verified Apple receipt does not contain this transaction.' });
+        return;
+      }
+      if (transaction?.cancellation_date || transaction?.cancellation_date_ms) {
+        res.status(400).json({ error: 'This Apple purchase was cancelled or refunded.' });
+        return;
+      }
+
+      appAccountToken = String(transaction?.app_account_token || transaction?.appAccountToken || '').trim();
+      originalTransactionId = transaction?.original_transaction_id || null;
+      const purchaseDateMs = Number(transaction?.purchase_date_ms || 0);
+      purchaseDate = purchaseDateMs > 0 ? new Date(purchaseDateMs).toISOString() : null;
     }
 
-    const transaction = receiptTransactions(payload).find(item =>
-      String(item?.transaction_id || '') === transactionId &&
-      String(item?.product_id || '') === productId
-    );
-
-    if (!transaction) {
-      res.status(400).json({ error: 'The verified Apple receipt does not contain this transaction.' });
-      return;
-    }
-
-    if (transaction?.cancellation_date || transaction?.cancellation_date_ms) {
-      res.status(400).json({ error: 'This Apple purchase was cancelled or refunded.' });
-      return;
-    }
-
-    const appAccountToken = String(transaction?.app_account_token || transaction?.appAccountToken || '').trim();
     if (appAccountToken && appAccountToken.toLowerCase() !== String(user.id).toLowerCase()) {
       res.status(403).json({ error: 'This Apple purchase belongs to a different Droxion account.' });
       return;
     }
-
-    const purchaseDateMs = Number(transaction?.purchase_date_ms || 0);
-    const purchaseDate = purchaseDateMs > 0 ? new Date(purchaseDateMs).toISOString() : null;
 
     const result = await callRpc(null, 'droxion_fulfill_apple_purchase', {
       p_user_id: user.id,
@@ -117,9 +229,9 @@ export default async function handler(req, res) {
       p_raw_payload: {
         transaction_id: transactionId,
         product_id: productId,
-        purchase_date_ms: transaction?.purchase_date_ms || null,
-        original_transaction_id: transaction?.original_transaction_id || null,
-        app_account_token: appAccountToken || null
+        original_transaction_id: originalTransactionId,
+        app_account_token: appAccountToken || null,
+        verification: jwsRepresentation ? 'storekit2_jws' : 'legacy_receipt'
       }
     });
 

--- a/src/DroxionWallet.jsx
+++ b/src/DroxionWallet.jsx
@@ -29,6 +29,7 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const paypalRef = useRef(null);
+  const recoveryStartedRef = useRef(false);
   const nativeStorePlatform = getNativeStorePlatform();
   const nativeMobile = Boolean(nativeStorePlatform);
   const isIOS = nativeStorePlatform === 'ios';
@@ -86,10 +87,12 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
 
   const webPrice = cents => `$${(Number(cents || 0) / 100).toFixed(2)}`;
 
-  async function verifyAppleTransaction(transaction, expectedProductId) {
+  async function verifyAppleTransaction(transaction, expectedProductId, refreshBalance = true) {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.access_token || !session?.user?.id) throw new Error('Please sign in again before buying coins.');
-    if (!transaction?.transactionId || !transaction?.receipt) throw new Error('Apple did not return a verifiable purchase receipt.');
+    if (!transaction?.transactionId || (!transaction?.jwsRepresentation && !transaction?.receipt)) {
+      throw new Error('Apple did not return a verifiable signed transaction.');
+    }
 
     const response = await fetch('/api/apple/verify-purchase', {
       method: 'POST',
@@ -98,7 +101,8 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
         Authorization: `Bearer ${session.access_token}`
       },
       body: JSON.stringify({
-        receipt: transaction.receipt,
+        receipt: transaction.receipt || null,
+        jwsRepresentation: transaction.jwsRepresentation || null,
         transactionId: transaction.transactionId,
         productId: expectedProductId
       })
@@ -112,9 +116,39 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
       console.warn('StoreKit finish retry needed', ackError);
     }
 
-    await onBalanceRefresh?.();
+    if (refreshBalance) await onBalanceRefresh?.();
     return payload;
   }
+
+  useEffect(() => {
+    if (!isIOS || loading || storeLoading || !appleProducts.length || recoveryStartedRef.current) return;
+    recoveryStartedRef.current = true;
+
+    (async () => {
+      try {
+        const { data: { session } } = await supabase.auth.getSession();
+        if (!session?.user?.id) return;
+        const ids = new Set(coinProducts.map(product => product.apple_product_id).filter(Boolean));
+        const { purchases } = await NativePurchases.getPurchases({ appAccountToken: session.user.id });
+        const recoverable = (purchases || []).filter(transaction => ids.has(transaction?.productIdentifier));
+        let recoveredCoins = 0;
+
+        for (const transaction of recoverable) {
+          try {
+            const result = await verifyAppleTransaction(transaction, transaction.productIdentifier, false);
+            if (!result?.alreadyCompleted) recoveredCoins += Number(result?.coinsGranted || 0);
+          } catch (recoverError) {
+            console.warn('Could not recover Apple purchase', transaction?.transactionId, recoverError);
+          }
+        }
+
+        if (recoverable.length) await onBalanceRefresh?.();
+        if (recoveredCoins > 0) setSuccess(`${recoveredCoins} previously purchased coins were restored to your Droxion wallet.`);
+      } catch (recoveryError) {
+        console.warn('Apple purchase recovery skipped', recoveryError);
+      }
+    })();
+  }, [isIOS, loading, storeLoading, appleProducts, products, onBalanceRefresh]);
 
   async function buyAppleCoins(product) {
     if (checkoutId) return;


### PR DESCRIPTION
Fix TestFlight coin purchases that complete in Apple's sheet but fail in Droxion with “Apple did not return a verifiable purchase receipt.”

- Accept StoreKit 2 `jwsRepresentation` when sandbox/TestFlight does not expose a legacy app receipt
- Verify the Apple JWS certificate chain, trusted Apple root fingerprint, ES256 signature, bundle ID, product ID, transaction ID, account token, and revocation state server-side before crediting coins
- Keep legacy receipt verification as fallback
- Recover previously unfinished StoreKit purchases with `getPurchases()` and idempotent backend fulfillment
- Finish StoreKit transactions only after Droxion server fulfillment

This addresses the exact TestFlight failure after purchasing a coin pack.