### PR TITLE
Fix Apple IAP verification and raise iOS target

### DIFF
--- a/api/apple/verify-purchase.js
+++ b/api/apple/verify-purchase.js
@@ -44,15 +44,30 @@ function certIsCurrentlyValid(cert) {
 
 async function loadAppleRoots() {
   if (!appleRootsPromise) {
-    appleRootsPromise = Promise.all(APPLE_ROOT_CERT_URLS.map(async url => {
-      const response = await fetch(url);
-      if (!response.ok) throw new Error('Could not load Apple root certificate.');
-      const cert = new X509Certificate(Buffer.from(await response.arrayBuffer()));
-      if (!APPLE_ROOT_SHA256.has(normalizedFingerprint(cert))) {
-        throw new Error('Downloaded Apple root certificate fingerprint was not trusted.');
+    appleRootsPromise = (async () => {
+      const settled = await Promise.allSettled(APPLE_ROOT_CERT_URLS.map(async url => {
+        const response = await fetch(url, { redirect: 'follow' });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        const cert = new X509Certificate(Buffer.from(await response.arrayBuffer()));
+        if (!APPLE_ROOT_SHA256.has(normalizedFingerprint(cert))) {
+          throw new Error('fingerprint mismatch');
+        }
+        return cert;
+      }));
+
+      const roots = settled
+        .filter(item => item.status === 'fulfilled')
+        .map(item => item.value);
+
+      if (!roots.length) {
+        const reasons = settled
+          .filter(item => item.status === 'rejected')
+          .map(item => item.reason?.message || String(item.reason))
+          .join('; ');
+        throw new Error(`Could not load a trusted Apple root certificate${reasons ? `: ${reasons}` : '.'}`);
       }
-      return cert;
-    }));
+      return roots;
+    })();
   }
   return appleRootsPromise;
 }
@@ -83,14 +98,12 @@ async function verifyStoreKitJws(jws) {
   if (!anchored) {
     const roots = await loadAppleRoots();
     anchored = roots.some(root =>
-      lastPresented.issuer === root.subject &&
       certIsCurrentlyValid(root) &&
+      lastPresented.issuer === root.subject &&
       lastPresented.verify(root.publicKey)
     );
   }
-  if (!anchored) {
-    throw new Error('Apple signed transaction did not chain to a trusted Apple root.');
-  }
+  if (!anchored) throw new Error('Apple signed transaction did not chain to a trusted Apple root.');
 
   const signedData = Buffer.from(`${encodedHeader}.${encodedPayload}`);
   const signature = base64UrlBuffer(encodedSignature);
@@ -274,7 +287,8 @@ export default async function handler(req, res) {
       environment
     });
   } catch (error) {
-    console.error('Apple purchase verification error:', error);
-    res.status(502).json({ error: error?.message || 'Apple purchase verification failed.' });
+    const message = error?.message || 'Apple purchase verification failed.';
+    console.error('Apple purchase verification error:', message, error?.stack || '');
+    res.status(502).json({ error: message });
   }
 }

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -60,6 +60,8 @@ workflows:
             npx cap add ios
           fi
           npx cap sync ios
+          sed -i '' "s/platform :ios, '[^']*'/platform :ios, '15.0'/" "${IOS_PROJECT_PATH}/Podfile"
+          ruby -e "p='${IOS_PROJECT_PATH}/App.xcodeproj/project.pbxproj'; s=File.read(p); s=s.gsub(/IPHONEOS_DEPLOYMENT_TARGET = [0-9.]+;/, 'IPHONEOS_DEPLOYMENT_TARGET = 15.0;'); File.write(p,s)"
 
       - name: Generate Droxion iOS branding
         script: |


### PR DESCRIPTION
Fix the remaining TestFlight Apple coin purchase verification failure and clean the App Store deployment target warning.

- Make Apple root certificate loading resilient: a retired/unavailable root URL no longer breaks every purchase verification
- Keep StoreKit 2 ES256 signature, certificate-chain, bundle/product/transaction/account-token and revocation checks
- Return/log the concrete verification error instead of only a generic failure
- Raise generated Capacitor iOS deployment target and Podfile to iOS 15.0

This is for the exact Build 50/TestFlight issue shown by the user.