### PR TITLE
Launch Droxion on Android

### DIFF
--- a/.github/ANDROID_RELEASE_CHECKLIST.md
+++ b/.github/ANDROID_RELEASE_CHECKLIST.md
@@ -1,0 +1,17 @@
+# Android release checklist
+
+- [ ] Play Console app created for `com.droxion.live`
+- [ ] Play developer account has production access or required closed testing is in progress
+- [ ] 100 / 550 / 1200 / 3000 coin one-time products are active
+- [ ] Android Publisher service account linked in Play Console
+- [ ] Vercel has `GOOGLE_PLAY_SERVICE_ACCOUNT_EMAIL`
+- [ ] Vercel has `GOOGLE_PLAY_SERVICE_ACCOUNT_PRIVATE_KEY`
+- [ ] GitHub has Android upload-keystore secrets
+- [ ] Signed `.aab` generated from Android Release workflow
+- [ ] Internal testing purchase succeeds and credits coins once
+- [ ] Camera and microphone work on a physical Android device
+- [ ] LIVE / chat / gift / report / block flows pass
+- [ ] Data Safety and content rating completed
+- [ ] Privacy policy and account deletion links completed
+- [ ] Store screenshots, icon, feature graphic, descriptions completed
+- [ ] Production release submitted

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,135 @@
+name: Droxion Android Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-android:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Android launch branch
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android API 36
+        run: sdkmanager "platforms;android-36" "build-tools;36.0.0"
+
+      - name: Install dependencies
+        run: |
+          npm config set audit false
+          npm config set fund false
+          npm install --no-audit --no-fund
+          npm install --no-save --no-audit --no-fund @capacitor/cli@7 @capacitor/android@7 @capacitor/assets@3.0.5
+
+      - name: Build web bundle
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.VITE_SUPABASE_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.VITE_SUPABASE_ANON_KEY }}
+          VITE_PAYPAL_CLIENT_ID: ${{ secrets.VITE_PAYPAL_CLIENT_ID }}
+        run: npm run build
+
+      - name: Create and sync Android project
+        run: |
+          if [ ! -d android ]; then
+            npx cap add android
+          fi
+          npx cap sync android
+
+      - name: Configure Android release
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          from pathlib import Path
+          import re
+
+          variables = Path('android/variables.gradle')
+          text = variables.read_text()
+          text = re.sub(r'compileSdkVersion\s*=\s*\d+', 'compileSdkVersion = 36', text)
+          text = re.sub(r'targetSdkVersion\s*=\s*\d+', 'targetSdkVersion = 36', text)
+          variables.write_text(text)
+
+          manifest = Path('android/app/src/main/AndroidManifest.xml')
+          text = manifest.read_text()
+          permissions = [
+              '<uses-permission android:name="android.permission.CAMERA" />',
+              '<uses-permission android:name="android.permission.RECORD_AUDIO" />',
+              '<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />'
+          ]
+          missing = [p for p in permissions if p not in text]
+          if missing:
+              text = text.replace('<application', '\n    ' + '\n    '.join(missing) + '\n\n    <application', 1)
+          manifest.write_text(text)
+          PY
+
+      - name: Generate Android branding
+        run: |
+          npx @capacitor/assets generate --android \
+            --assetPath assets \
+            --iconBackgroundColor '#08080c' \
+            --iconBackgroundColorDark '#08080c' \
+            --splashBackgroundColor '#08080c' \
+            --splashBackgroundColorDark '#08080c'
+
+      - name: Configure release signing
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: |
+          test -n "$ANDROID_KEYSTORE_BASE64"
+          test -n "$ANDROID_KEYSTORE_PASSWORD"
+          test -n "$ANDROID_KEY_ALIAS"
+          test -n "$ANDROID_KEY_PASSWORD"
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$GITHUB_WORKSPACE/droxion-upload.jks"
+          cat >> android/app/build.gradle <<'GRADLE'
+
+          android {
+              signingConfigs {
+                  droxionRelease {
+                      storeFile file(System.getenv("ANDROID_KEYSTORE_PATH"))
+                      storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                      keyAlias System.getenv("ANDROID_KEY_ALIAS")
+                      keyPassword System.getenv("ANDROID_KEY_PASSWORD")
+                  }
+              }
+              buildTypes {
+                  release {
+                      signingConfig signingConfigs.droxionRelease
+                  }
+              }
+          }
+          GRADLE
+
+      - name: Build signed Android App Bundle
+        working-directory: android
+        env:
+          ANDROID_KEYSTORE_PATH: ${{ github.workspace }}/droxion-upload.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: ./gradlew bundleRelease
+
+      - name: Upload Play Store AAB
+        uses: actions/upload-artifact@v4
+        with:
+          name: droxion-android-release
+          path: android/app/build/outputs/bundle/release/app-release.aab
+          if-no-files-found: error

--- a/ANDROID_LAUNCH.md
+++ b/ANDROID_LAUNCH.md
@@ -1,0 +1,59 @@
+# Droxion Android launch
+
+## Google Play app
+
+- Package name: `com.droxion.live`
+- App name: `Droxion Live`
+- Target SDK: Android 16 / API 36
+- Upload format: Android App Bundle (`.aab`)
+
+## One-time coin products
+
+Create these Google Play one-time products using the existing Droxion IDs:
+
+| Product ID | Coins |
+| --- | ---: |
+| `com.droxion.live.coins100` | 100 |
+| `com.droxion.live.coins550` | 550 |
+| `com.droxion.live.coins1200` | 1,200 |
+| `com.droxion.live.coins3000` | 3,000 |
+
+The database `google_product_id` values already match these IDs.
+
+## Vercel production secrets
+
+The server-side Google Play verifier requires:
+
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_EMAIL`
+- `GOOGLE_PLAY_SERVICE_ACCOUNT_PRIVATE_KEY`
+
+Use a Google Cloud service account that has Android Publisher access to the Droxion app in Play Console. Keep the private key only in Vercel environment variables; never commit it.
+
+Existing Supabase production variables must remain available because `/api/google/verify-purchase` authenticates the Droxion user and performs wallet fulfillment server-side.
+
+## GitHub Actions release secrets
+
+The Android release workflow `.github/workflows/android-release.yml` expects:
+
+- `VITE_SUPABASE_URL`
+- `VITE_SUPABASE_ANON_KEY`
+- `VITE_PAYPAL_CLIENT_ID` (optional for Android-native checkout, but retained for the shared web build)
+- `ANDROID_KEYSTORE_BASE64`
+- `ANDROID_KEYSTORE_PASSWORD`
+- `ANDROID_KEY_ALIAS`
+- `ANDROID_KEY_PASSWORD`
+
+`ANDROID_KEYSTORE_BASE64` must contain the base64-encoded Google Play upload keystore.
+
+## Test before production
+
+1. Create and activate the four one-time products in Play Console.
+2. Add license testers / internal testers.
+3. Add the Google Play service account credentials to Vercel production.
+4. Add Android signing secrets to GitHub Actions.
+5. Run **Droxion Android Release** from GitHub Actions to produce `app-release.aab`.
+6. Upload the AAB to Play Console Internal testing.
+7. Test sign-up/login, 21+ flow, camera, microphone, LIVE, chat, reports/blocks, coin purchase, gift sending, and wallet balance.
+8. Confirm each test purchase credits coins once and can be purchased again after consumption.
+9. Complete Data Safety, content rating, app access, privacy policy, account deletion, UGC/moderation declarations, screenshots, icon and feature graphic.
+10. Promote the tested release to production when Play Console requirements are satisfied.

--- a/ANDROID_STATUS.md
+++ b/ANDROID_STATUS.md
@@ -1,0 +1,20 @@
+# Android launch status
+
+Prepared in code:
+
+- Capacitor Android release build workflow targeting API 36
+- Android camera/microphone manifest permissions in release workflow
+- Google Play one-time coin product IDs mapped to Droxion products
+- Native Google Play product loading and purchase flow in `DroxionWallet`
+- Server-side Google Play purchase verification through Android Publisher API
+- Idempotent Google Play wallet fulfillment and transaction ledger
+- Server-side consumption after successful wallet fulfillment
+
+External setup still required before the first Play test build can complete:
+
+- Google Play Console app for package `com.droxion.live`
+- Four activated one-time products
+- Google Play / Google Cloud service account with Android Publisher access
+- Vercel production variables for the service account email and private key
+- Android upload keystore and GitHub Actions signing secrets
+- Play Console store listing/compliance forms and tester configuration

--- a/GOOGLE_PLAY_PRODUCTS.csv
+++ b/GOOGLE_PLAY_PRODUCTS.csv
@@ -1,0 +1,5 @@
+product_id,name,coins,price_usd
+com.droxion.live.coins100,100 Coins,100,1.99
+com.droxion.live.coins550,550 Coins,550,7.99
+com.droxion.live.coins1200,1200 Coins,1200,14.99
+com.droxion.live.coins3000,3000 Coins,3000,29.99

--- a/PLAY_CONSOLE_MANUAL_STEPS.md
+++ b/PLAY_CONSOLE_MANUAL_STEPS.md
@@ -1,0 +1,11 @@
+# Play Console manual steps
+
+1. Create the Droxion Live Android app with package `com.droxion.live`.
+2. Create the four one-time products listed in `GOOGLE_PLAY_PRODUCTS.csv`.
+3. Link a Google Cloud service account and grant it Android Publisher access for Droxion Live.
+4. Put that service account email/private key in Vercel production environment variables.
+5. Configure an Android upload key in GitHub Actions secrets.
+6. Generate and upload the signed AAB to Internal testing.
+7. Add tester accounts and complete a real Play Billing test purchase.
+8. Complete store listing, Data Safety, content rating, app access, privacy/account deletion and UGC declarations.
+9. Promote the tested build to production once Play Console allows production rollout.

--- a/api/google/verify-purchase.js
+++ b/api/google/verify-purchase.js
@@ -1,0 +1,162 @@
+import { createSign } from 'node:crypto';
+import { callRpc, getSupabaseConfig, getSupabaseHeaders, getSupabaseUser, readJsonBody } from '../paypal/lib.js';
+
+const PACKAGE_NAME = 'com.droxion.live';
+const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GOOGLE_SCOPE = 'https://www.googleapis.com/auth/androidpublisher';
+const ANDROID_PUBLISHER_BASE = 'https://androidpublisher.googleapis.com/androidpublisher/v3/applications';
+const ALLOWED_CLIENT_ORIGINS = new Set([
+  'capacitor://localhost',
+  'ionic://localhost',
+  'http://localhost',
+  'https://localhost',
+  'https://droxion.com',
+  'https://www.droxion.com'
+]);
+
+function applyCors(req, res) {
+  const origin = String(req.headers.origin || '').trim();
+  if (origin && ALLOWED_CLIENT_ORIGINS.has(origin)) res.setHeader('Access-Control-Allow-Origin', origin);
+  res.setHeader('Vary', 'Origin');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+  res.setHeader('Access-Control-Max-Age', '86400');
+}
+
+function base64url(input) {
+  return Buffer.from(input).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function getGoogleCredentials() {
+  const email = String(process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_EMAIL || '').trim();
+  const privateKey = String(process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_PRIVATE_KEY || '').replace(/\\n/g, '\n').trim();
+  if (!email || !privateKey) throw new Error('Google Play service account credentials are not configured.');
+  return { email, privateKey };
+}
+
+async function getGoogleAccessToken() {
+  const { email, privateKey } = getGoogleCredentials();
+  const now = Math.floor(Date.now() / 1000);
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const claims = base64url(JSON.stringify({
+    iss: email,
+    scope: GOOGLE_SCOPE,
+    aud: GOOGLE_TOKEN_URL,
+    iat: now,
+    exp: now + 3600
+  }));
+  const unsigned = `${header}.${claims}`;
+  const signer = createSign('RSA-SHA256');
+  signer.update(unsigned);
+  signer.end();
+  const signature = signer.sign(privateKey).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+
+  const response = await fetch(GOOGLE_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer', assertion: `${unsigned}.${signature}` })
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || !payload?.access_token) throw new Error(payload?.error_description || 'Google Play authentication failed.');
+  return payload.access_token;
+}
+
+async function findCoinProductByGoogleId(productId) {
+  const { supabaseUrl } = getSupabaseConfig();
+  const response = await fetch(
+    `${supabaseUrl}/rest/v1/droxion_products?select=id,product_type,name,coins_granted,active,google_product_id&active=eq.true&product_type=eq.coin_pack&google_product_id=eq.${encodeURIComponent(productId)}`,
+    { headers: getSupabaseHeaders(null, true) }
+  );
+  const data = await response.json().catch(() => []);
+  if (!response.ok) throw new Error('Unable to load the Droxion coin package.');
+  return Array.isArray(data) && data.length ? data[0] : null;
+}
+
+async function getGooglePurchase(accessToken, productId, purchaseToken) {
+  const url = `${ANDROID_PUBLISHER_BASE}/${encodeURIComponent(PACKAGE_NAME)}/purchases/products/${encodeURIComponent(productId)}/tokens/${encodeURIComponent(purchaseToken)}`;
+  const response = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(payload?.error?.message || 'Google Play could not verify this purchase.');
+  return payload;
+}
+
+async function consumeGooglePurchase(accessToken, productId, purchaseToken) {
+  const url = `${ANDROID_PUBLISHER_BASE}/${encodeURIComponent(PACKAGE_NAME)}/purchases/products/${encodeURIComponent(productId)}/tokens/${encodeURIComponent(purchaseToken)}:consume`;
+  const response = await fetch(url, { method: 'POST', headers: { Authorization: `Bearer ${accessToken}` } });
+  if (!response.ok && response.status !== 409) {
+    const payload = await response.json().catch(() => ({}));
+    throw new Error(payload?.error?.message || 'Google Play purchase could not be consumed.');
+  }
+}
+
+export default async function handler(req, res) {
+  applyCors(req, res);
+  if (req.method === 'OPTIONS') return res.status(204).end();
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST, OPTIONS');
+    return res.status(405).json({ error: 'Method not allowed.' });
+  }
+
+  try {
+    const authHeader = req.headers.authorization || '';
+    const accessToken = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : '';
+    const user = await getSupabaseUser(accessToken);
+    const body = await readJsonBody(req);
+    const purchaseToken = typeof body?.purchaseToken === 'string' ? body.purchaseToken.trim() : '';
+    const productId = typeof body?.productId === 'string' ? body.productId.trim() : '';
+
+    if (!purchaseToken || !productId) return res.status(400).json({ error: 'Google Play purchase token and product ID are required.' });
+
+    const product = await findCoinProductByGoogleId(productId);
+    if (!product || Number(product.coins_granted) <= 0) return res.status(400).json({ error: 'This Google Play product is not an active Droxion coin package.' });
+
+    const googleAccessToken = await getGoogleAccessToken();
+    const purchase = await getGooglePurchase(googleAccessToken, productId, purchaseToken);
+
+    // Android Publisher ProductPurchase: 0=purchased, 1=canceled, 2=pending.
+    if (Number(purchase?.purchaseState) !== 0) {
+      const state = Number(purchase?.purchaseState) === 2 ? 'pending' : 'not valid';
+      return res.status(409).json({ error: `This Google Play purchase is ${state}.` });
+    }
+
+    const purchaseTimeMs = Number(purchase?.purchaseTimeMillis || 0);
+    const result = await callRpc(null, 'droxion_fulfill_google_purchase', {
+      p_user_id: user.id,
+      p_purchase_token: purchaseToken,
+      p_order_id: purchase?.orderId || null,
+      p_product_id: productId,
+      p_package_id: product.id,
+      p_coins: Number(product.coins_granted),
+      p_purchase_state: Number(purchase?.purchaseState ?? 0),
+      p_consumption_state: Number(purchase?.consumptionState ?? 0),
+      p_acknowledgement_state: Number(purchase?.acknowledgementState ?? 0),
+      p_purchase_time: purchaseTimeMs > 0 ? new Date(purchaseTimeMs).toISOString() : null,
+      p_raw_payload: {
+        order_id: purchase?.orderId || null,
+        product_id: productId,
+        obfuscated_external_account_id: purchase?.obfuscatedExternalAccountId || null,
+        purchase_type: purchase?.purchaseType ?? null,
+        region_code: purchase?.regionCode || null
+      }
+    });
+
+    try {
+      await consumeGooglePurchase(googleAccessToken, productId, purchaseToken);
+    } catch (consumeError) {
+      console.error('Google Play consume retry needed:', consumeError?.message || consumeError);
+    }
+
+    return res.status(200).json({
+      ok: true,
+      alreadyCompleted: Boolean(result?.already_completed),
+      coinsGranted: Number(result?.coins || product.coins_granted),
+      coinBalance: Number(result?.coin_balance || 0),
+      orderId: purchase?.orderId || null,
+      productId
+    });
+  } catch (error) {
+    const message = error?.message || 'Google Play purchase verification failed.';
+    console.error('Google Play purchase verification error:', message, error?.stack || '');
+    return res.status(502).json({ error: message });
+  }
+}

--- a/src/DroxionWallet.jsx
+++ b/src/DroxionWallet.jsx
@@ -21,7 +21,7 @@ function storeProductKey(product) {
 
 export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free', onClose, onBalanceRefresh }) {
   const [products, setProducts] = useState([]);
-  const [appleProducts, setAppleProducts] = useState([]);
+  const [storeProducts, setStoreProducts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [storeLoading, setStoreLoading] = useState(false);
   const [checkoutId, setCheckoutId] = useState('');
@@ -35,13 +35,14 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
   const nativeStorePlatform = getNativeStorePlatform();
   const nativeMobile = Boolean(nativeStorePlatform);
   const isIOS = nativeStorePlatform === 'ios';
+  const isAndroid = nativeStorePlatform === 'android';
 
   useEffect(() => {
     let alive = true;
     (async () => {
       const { data, error: queryError } = await supabase
         .from('droxion_products')
-        .select('id,product_type,name,price_cents,coins_granted,plan,sort_order,apple_product_id')
+        .select('id,product_type,name,price_cents,coins_granted,plan,sort_order,apple_product_id,google_product_id')
         .eq('active', true)
         .order('sort_order');
       if (!alive) return;
@@ -54,38 +55,44 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
 
   const coinProducts = products.filter(product => product.product_type === 'coin_pack');
   const plans = products.filter(product => product.product_type === 'subscription');
-  const appleProductMap = useMemo(() => {
+  const storeProductMap = useMemo(() => {
     const map = new Map();
-    appleProducts.forEach(product => {
+    storeProducts.forEach(product => {
       const key = storeProductKey(product);
       if (key) map.set(key, product);
     });
     return map;
-  }, [appleProducts]);
+  }, [storeProducts]);
+
+  function productStoreId(product) {
+    if (isIOS) return product.apple_product_id;
+    if (isAndroid) return product.google_product_id;
+    return '';
+  }
 
   useEffect(() => {
-    if (!isIOS || loading || !coinProducts.length) return;
+    if ((!isIOS && !isAndroid) || loading || !coinProducts.length) return;
     let alive = true;
     (async () => {
       setStoreLoading(true);
       try {
         const { isBillingSupported } = await NativePurchases.isBillingSupported();
-        if (!isBillingSupported) throw new Error('Apple In-App Purchase is not available on this device.');
-        const ids = coinProducts.map(product => product.apple_product_id).filter(Boolean);
-        if (!ids.length) throw new Error('Droxion coin products are not configured for the App Store.');
-        const { products: storeProducts } = await NativePurchases.getProducts({
+        if (!isBillingSupported) throw new Error(`${isAndroid ? 'Google Play Billing' : 'Apple In-App Purchase'} is not available on this device.`);
+        const ids = coinProducts.map(productStoreId).filter(Boolean);
+        if (!ids.length) throw new Error(`Droxion coin products are not configured for ${isAndroid ? 'Google Play' : 'the App Store'}.`);
+        const { products: loadedProducts } = await NativePurchases.getProducts({
           productIdentifiers: ids,
           productType: PURCHASE_TYPE.INAPP
         });
-        if (alive) setAppleProducts(storeProducts || []);
+        if (alive) setStoreProducts(loadedProducts || []);
       } catch (err) {
-        if (alive) setError(err?.message || 'Could not load Apple coin products.');
+        if (alive) setError(err?.message || 'Could not load store coin products.');
       } finally {
         if (alive) setStoreLoading(false);
       }
     })();
     return () => { alive = false; };
-  }, [isIOS, loading, products]);
+  }, [isIOS, isAndroid, loading, products]);
 
   const webPrice = cents => `$${(Number(cents || 0) / 100).toFixed(2)}`;
 
@@ -96,13 +103,9 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
       throw new Error('Apple did not return a verifiable signed transaction.');
     }
 
-    const verifyUrl = `${DROXION_API_ORIGIN}/api/apple/verify-purchase`;
-    const response = await fetch(verifyUrl, {
+    const response = await fetch(`${DROXION_API_ORIGIN}/api/apple/verify-purchase`, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${session.access_token}`
-      },
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
       body: JSON.stringify({
         receipt: transaction.receipt || null,
         jwsRepresentation: transaction.jwsRepresentation || null,
@@ -111,9 +114,7 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
       })
     });
     const payload = await response.json().catch(() => ({}));
-    if (!response.ok || !payload?.ok) {
-      throw new Error(payload?.error || `Apple purchase verification failed (${response.status}).`);
-    }
+    if (!response.ok || !payload?.ok) throw new Error(payload?.error || `Apple purchase verification failed (${response.status}).`);
 
     try {
       await NativePurchases.acknowledgePurchase({ purchaseToken: transaction.transactionId });
@@ -125,42 +126,60 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
     return payload;
   }
 
+  async function verifyGoogleTransaction(transaction, expectedProductId, refreshBalance = true) {
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token || !session?.user?.id) throw new Error('Please sign in again before buying coins.');
+    if (!transaction?.purchaseToken) throw new Error('Google Play did not return a verifiable purchase token.');
+
+    const response = await fetch(`${DROXION_API_ORIGIN}/api/google/verify-purchase`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
+      body: JSON.stringify({ purchaseToken: transaction.purchaseToken, productId: expectedProductId })
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok || !payload?.ok) throw new Error(payload?.error || `Google Play purchase verification failed (${response.status}).`);
+    if (refreshBalance) await onBalanceRefresh?.();
+    return payload;
+  }
+
   useEffect(() => {
-    if (!isIOS || loading || storeLoading || !appleProducts.length || recoveryStartedRef.current) return;
+    if ((!isIOS && !isAndroid) || loading || storeLoading || !storeProducts.length || recoveryStartedRef.current) return;
     recoveryStartedRef.current = true;
 
     (async () => {
       try {
         const { data: { session } } = await supabase.auth.getSession();
         if (!session?.user?.id) return;
-        const ids = new Set(coinProducts.map(product => product.apple_product_id).filter(Boolean));
+        const ids = new Set(coinProducts.map(productStoreId).filter(Boolean));
         const { purchases } = await NativePurchases.getPurchases({ appAccountToken: session.user.id });
         const recoverable = (purchases || []).filter(transaction => ids.has(transaction?.productIdentifier));
         let recoveredCoins = 0;
 
         for (const transaction of recoverable) {
           try {
-            const result = await verifyAppleTransaction(transaction, transaction.productIdentifier, false);
+            const result = isAndroid
+              ? await verifyGoogleTransaction(transaction, transaction.productIdentifier, false)
+              : await verifyAppleTransaction(transaction, transaction.productIdentifier, false);
             if (!result?.alreadyCompleted) recoveredCoins += Number(result?.coinsGranted || 0);
           } catch (recoverError) {
-            console.warn('Could not recover Apple purchase', transaction?.transactionId, recoverError);
+            console.warn('Could not recover native purchase', transaction?.transactionId, recoverError);
           }
         }
 
         if (recoverable.length) await onBalanceRefresh?.();
         if (recoveredCoins > 0) setSuccess(`${recoveredCoins} previously purchased coins were restored to your Droxion wallet.`);
       } catch (recoveryError) {
-        console.warn('Apple purchase recovery skipped', recoveryError);
+        console.warn('Native purchase recovery skipped', recoveryError);
       }
     })();
-  }, [isIOS, loading, storeLoading, appleProducts, products, onBalanceRefresh]);
+  }, [isIOS, isAndroid, loading, storeLoading, storeProducts, products, onBalanceRefresh]);
 
-  async function buyAppleCoins(product) {
+  async function buyNativeCoins(product) {
     if (checkoutId) return;
-    const productId = product.apple_product_id;
-    const storeProduct = appleProductMap.get(productId);
+    const productId = productStoreId(product);
+    const storeProduct = storeProductMap.get(productId);
     if (!productId || !storeProduct) {
-      setError('This coin pack is not available from Apple yet.');
+      setError(`This coin pack is not available from ${isAndroid ? 'Google Play' : 'Apple'} yet.`);
       return;
     }
 
@@ -180,10 +199,16 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
         autoAcknowledgePurchases: false
       });
 
-      const result = await verifyAppleTransaction(transaction, productId);
+      if (isAndroid && String(transaction?.purchaseState || '') === '0') {
+        throw new Error('Google Play payment is still pending. Coins will be added after the payment completes.');
+      }
+
+      const result = isAndroid
+        ? await verifyGoogleTransaction(transaction, productId)
+        : await verifyAppleTransaction(transaction, productId);
       setSuccess(`${result.coinsGranted || product.coins_granted} coins added to your Droxion wallet.`);
     } catch (err) {
-      const message = String(err?.message || 'Apple purchase was not completed.');
+      const message = String(err?.message || 'Store purchase was not completed.');
       if (!/cancel/i.test(message)) setError(message);
     } finally {
       setCheckoutId('');
@@ -191,14 +216,11 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
   }
 
   async function buyCoins(product) {
-    if (isIOS) {
-      await buyAppleCoins(product);
+    if (isIOS || isAndroid) {
+      await buyNativeCoins(product);
       return;
     }
-    if (nativeMobile) {
-      setError('Coin purchases on Android will use Google Play Billing in the Android release.');
-      return;
-    }
+    if (nativeMobile) return;
     if (checkoutId) return;
     setError('');
     setSuccess('');
@@ -212,10 +234,7 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
       if (!session?.access_token) throw new Error('Please sign in again before buying coins.');
       const response = await fetch('/api/paypal/create-order', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${session.access_token}`
-        },
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
         body: JSON.stringify({ packageId: product.id })
       });
       const payload = await response.json().catch(() => ({}));
@@ -269,10 +288,7 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
           const orderId = data?.orderID || paypalOrderId;
           const response = await fetch('/api/paypal/capture-order', {
             method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${session.access_token}`
-            },
+            headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${session.access_token}` },
             body: JSON.stringify({ orderId })
           });
           const payload = await response.json().catch(() => ({}));
@@ -320,19 +336,17 @@ export default function DroxionWallet({ coins = 0, freeMatches = 0, plan = 'free
         {success && <div className="walletSuccess">{success}</div>}
 
         <h3>Buy Coins</h3>
-        {loading || (isIOS && storeLoading) ? <p className="walletMuted">Loading store…</p> : nativeStorePlatform === 'android' ? (
-          <div className="publishBillingNotice">Google Play Billing will be enabled in the Android release.</div>
-        ) : (
+        {loading || ((isIOS || isAndroid) && storeLoading) ? <p className="walletMuted">Loading store…</p> : (
           <div className="walletGrid">
             {coinProducts.map(product => {
-              const storeProduct = isIOS ? appleProductMap.get(product.apple_product_id) : null;
-              const displayPrice = isIOS ? (storeProduct?.priceString || 'Unavailable') : webPrice(product.price_cents);
-              const unavailable = isIOS && !storeProduct;
+              const nativeProduct = (isIOS || isAndroid) ? storeProductMap.get(productStoreId(product)) : null;
+              const displayPrice = (isIOS || isAndroid) ? (nativeProduct?.priceString || 'Unavailable') : webPrice(product.price_cents);
+              const unavailable = (isIOS || isAndroid) && !nativeProduct;
               return (
                 <button key={product.id} disabled={Boolean(checkoutId) || unavailable} onClick={() => buyCoins(product)}>
                   <Coins size={22} />
                   <strong>{product.coins_granted} coins</strong>
-                  <span>{checkoutId === product.id ? (isIOS ? 'Purchasing…' : 'Opening PayPal…') : displayPrice}</span>
+                  <span>{checkoutId === product.id ? ((isIOS || isAndroid) ? 'Purchasing…' : 'Opening PayPal…') : displayPrice}</span>
                 </button>
               );
             })}

--- a/src/LiveProfile.jsx
+++ b/src/LiveProfile.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
-import { ArrowLeft, BadgeCheck, Banknote, Camera, ChevronRight, Coins, Edit3, HelpCircle, Landmark, LogOut, ShieldCheck, Sparkles, UserRound, Users } from 'lucide-react';
+import { ArrowLeft, BadgeCheck, Banknote, Camera, ChevronRight, Coins, Edit3, HelpCircle, Landmark, LogOut, ShieldCheck, Sparkles, Trash2, UserRound, Users } from 'lucide-react';
 import { supabase } from './supabaseClient';
 import './live-profile.css';
+import './profile-account-actions.css';
 
 function ageFromDob(value) {
   if (!value) return null;
@@ -15,6 +16,7 @@ function ageFromDob(value) {
 }
 
 export default function LiveProfile({ coins = 0, onOpenWallet }) {
+  const [loading, setLoading] = useState(true);
   const [user, setUser] = useState(null);
   const [profile, setProfile] = useState(null);
   const [followers, setFollowers] = useState(0);
@@ -25,6 +27,7 @@ export default function LiveProfile({ coins = 0, onOpenWallet }) {
   const [payouts, setPayouts] = useState([]);
   const [view, setView] = useState('main');
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const [notice, setNotice] = useState('');
   const [networkMode, setNetworkMode] = useState('followers');
   const [networkRows, setNetworkRows] = useState([]);
@@ -38,25 +41,35 @@ export default function LiveProfile({ coins = 0, onOpenWallet }) {
   useEffect(() => { loadAll(); }, []);
 
   async function loadAll() {
-    const { data: auth } = await supabase.auth.getUser();
-    const currentUser = auth?.user || null;
-    setUser(currentUser);
-    if (!currentUser) return;
-    const [profileResult, statsResult, creatorResult, earningsResult, walletResult, payoutResult] = await Promise.all([
-      supabase.from('droxion_profiles').select('*').eq('user_id', currentUser.id).maybeSingle(),
-      supabase.rpc('droxion_follow_stats'),
-      supabase.from('droxion_creator_accounts').select('status').eq('user_id', currentUser.id).maybeSingle(),
-      supabase.from('droxion_creator_earnings').select('amount_cents').eq('user_id', currentUser.id),
-      supabase.rpc('droxion_creator_wallet_status'),
-      supabase.from('droxion_payout_requests').select('id,provider,creator_coins,amount_cents,status,created_at,paypal_email,bank_name,bank_account_number').order('created_at', { ascending: false }).limit(10)
-    ]);
-    setProfile(profileResult.data || null);
-    setFollowers(Number(statsResult.data?.followers || 0));
-    setFollowing(Number(statsResult.data?.following || 0));
-    setCreator(creatorResult.data || null);
-    setEarnings((earningsResult.data || []).reduce((sum, row) => sum + Number(row.amount_cents || 0), 0));
-    setCreatorWallet(walletResult.data || null);
-    setPayouts(payoutResult.data || []);
+    try {
+      const { data: auth } = await supabase.auth.getUser();
+      const currentUser = auth?.user || null;
+      setUser(currentUser);
+      if (!currentUser) {
+        setProfile(null);
+        return;
+      }
+      const [profileResult, statsResult, creatorResult, earningsResult, walletResult, payoutResult] = await Promise.all([
+        supabase.from('droxion_profiles').select('*').eq('user_id', currentUser.id).maybeSingle(),
+        supabase.rpc('droxion_follow_stats'),
+        supabase.from('droxion_creator_accounts').select('status').eq('user_id', currentUser.id).maybeSingle(),
+        supabase.from('droxion_creator_earnings').select('amount_cents').eq('user_id', currentUser.id),
+        supabase.rpc('droxion_creator_wallet_status'),
+        supabase.from('droxion_payout_requests').select('id,provider,creator_coins,amount_cents,status,created_at,paypal_email,bank_name,bank_account_number').order('created_at', { ascending: false }).limit(10)
+      ]);
+      setProfile(profileResult.data || null);
+      setFollowers(Number(statsResult.data?.followers || 0));
+      setFollowing(Number(statsResult.data?.following || 0));
+      setCreator(creatorResult.data || null);
+      setEarnings((earningsResult.data || []).reduce((sum, row) => sum + Number(row.amount_cents || 0), 0));
+      setCreatorWallet(walletResult.data || null);
+      setPayouts(payoutResult.data || []);
+    } catch (error) {
+      console.error('Droxion profile load error:', error);
+      setNotice('Unable to load your profile. Please try again.');
+    } finally {
+      setLoading(false);
+    }
   }
 
   const age = useMemo(() => ageFromDob(profile?.date_of_birth), [profile?.date_of_birth]);
@@ -153,13 +166,36 @@ export default function LiveProfile({ coins = 0, onOpenWallet }) {
     await loadAll();
   }
 
-  async function logout() { await supabase.auth.signOut({ scope: 'local' }); window.location.assign('/login'); }
+  async function logout() {
+    await supabase.auth.signOut({ scope: 'local' }).catch(() => {});
+    window.location.assign('/login');
+  }
+
+  async function deleteAccount() {
+    if (deleting) return;
+    if (!window.confirm('Delete your Droxion account permanently? This cannot be undone.')) return;
+    if (!window.confirm('Are you sure? Your profile, LIVE data, messages and account access will be deleted.')) return;
+
+    setDeleting(true);
+    setNotice('');
+    const { error } = await supabase.functions.invoke('delete-my-account', { body: {} });
+    if (error) {
+      setDeleting(false);
+      setNotice(error.message || 'Could not delete account.');
+      return;
+    }
+
+    await supabase.auth.signOut({ scope: 'local' }).catch(() => {});
+    window.location.assign('/login');
+  }
+
   function Back({ title }) { return <div className="lpSubHead"><button onClick={() => { setView('main'); setNotice(''); }}><ArrowLeft size={19} /></button><h2>{title}</h2></div>; }
 
+  if (loading) return <section className="lpPage"><div className="lpLoading">Loading your profile…</div></section>;
   if (!user) return <section className="lpPage lpSignedOut"><UserRound size={38} /><h2>Sign in to your Droxion profile</h2><a href="/login">Sign in</a></section>;
   if (!profile) return <section className="lpPage"><div className="lpLoading">Loading your profile…</div></section>;
 
-  if (view === 'edit') return <section className="lpPage"><Back title="Edit Profile" /><div className="lpEditor"><label>Display name<input value={profile.display_name || ''} onChange={e => setProfile(p => ({ ...p, display_name: e.target.value }))} /></label><label>Username<input value={profile.username || ''} onChange={e => setProfile(p => ({ ...p, username: e.target.value }))} /></label><label>Bio<textarea value={profile.bio || ''} onChange={e => setProfile(p => ({ ...p, bio: e.target.value }))} /></label><div className="lpTwoCol"><label>Country<input value={profile.country || ''} onChange={e => setProfile(p => ({ ...p, country: e.target.value }))} /></label><label>Language<input value={profile.language || ''} onChange={e => setProfile(p => ({ ...p, language: e.target.value }))} /></label></div><label>Interests<input value={interests.join(', ')} onChange={e => setProfile(p => ({ ...p, interests: e.target.value.split(',').map(x => x.trim()).filter(Boolean).slice(0, 12) }))} /></label><button className="lpSave" disabled={saving} onClick={saveProfile}>{saving ? 'Saving…' : 'Save Profile'}</button>{notice && <div className="lpNotice">{notice}</div>}</div></section>;
+  if (view === 'edit') return <section className="lpPage"><Back title="Edit Profile" /><div className="lpEditor"><label>Display name<input value={profile.display_name || ''} onChange={e => setProfile(p => ({ ...p, display_name: e.target.value }))} /></label><label>Username<input value={profile.username || ''} onChange={e => setProfile(p => ({ ...p, username: e.target.value }))} /></label><label>Bio<textarea value={profile.bio || ''} onChange={e => setProfile(p => ({ ...p, bio: e.target.value }))} /></label><div className="lpTwoCol"><label>Country<input value={profile.country || ''} onChange={e => setProfile(p => ({ ...p, country: e.target.value }))} /></label><label>Language<input value={profile.language || ''} onChange={e => setProfile(p => ({ ...p, language: e.target.value }))} /></label></div><label>Interests<input value={interests.join(', ')} onChange={e => setProfile(p => ({ ...p, interests: e.target.value.split(',').map(x => x.trim()).filter(Boolean).slice(0, 12) }))} /></label><button className="lpSave" disabled={saving} onClick={saveProfile}>{saving ? 'Saving…' : 'Save Profile'}</button>{notice && <div className="lpNotice">{notice}</div>}<section className="profileEditAccountActions" aria-label="Account actions"><div className="profileEditAccountHead"><strong>Account</strong><span>Sign out or permanently remove your Droxion account.</span></div><button type="button" className="profileEditLogout" onClick={logout}><span className="profileEditActionIcon" aria-hidden="true"><LogOut size={19} /></span><span><strong>Log Out</strong><small>Sign out of this device</small></span><span className="profileEditChevron" aria-hidden="true">›</span></button><button type="button" className={`profileEditDelete${deleting ? ' isDeleting' : ''}`} onClick={deleteAccount} disabled={deleting}><span className="profileEditActionIcon" aria-hidden="true"><Trash2 size={19} /></span><span><strong>{deleting ? 'Deleting Account…' : 'Delete Account'}</strong><small>Permanently delete your Droxion account and data</small></span><span className="profileEditChevron" aria-hidden="true">›</span></button></section></div></section>;
 
   if (view === 'live-settings') return <section className="lpPage"><Back title="LIVE Settings" /><div className="lpCreatorCard"><div className="lpCreatorTop"><Camera size={19} /><strong>Camera & microphone</strong></div><p className="lpSettingText">Droxion needs camera and microphone permission only when you go LIVE or join a creator on camera.</p><div className="lpStatusBox"><strong>{cameraState}</strong><small>Test permissions before your next LIVE.</small></div><button className="lpSave" onClick={testCamera}>Test Camera & Microphone</button>{notice && <div className="lpNotice">{notice}</div>}</div></section>;
 
@@ -171,5 +207,5 @@ export default function LiveProfile({ coins = 0, onOpenWallet }) {
 
   if (view === 'withdraw') return <section className="lpPage"><Back title="Withdraw Earnings" /><div className="lpCreatorCard"><div className="lpCreatorTop"><Banknote size={19} /><strong>Creator balance</strong></div><div className="lpPayoutBalance"><strong>${(availableCents / 100).toFixed(2)}</strong><span>Available to withdraw</span></div><small className="lpPayoutHelp">Minimum withdrawal: ${(minimumPayout / 100).toFixed(2)} · Requests are reviewed before payout.</small></div><div className="lpEditor"><div className="lpSegment"><button className={payoutMethod === 'paypal' ? 'active' : ''} onClick={() => setPayoutMethod('paypal')}>PayPal</button><button className={payoutMethod === 'bank' ? 'active' : ''} onClick={() => setPayoutMethod('bank')}>Bank Transfer</button></div><label>Amount (USD)<input inputMode="decimal" value={payoutForm.amount} onChange={e => setPayoutForm(f => ({ ...f, amount: e.target.value }))} placeholder="25.00" /></label>{payoutMethod === 'paypal' ? <label>PayPal email<input type="email" value={payoutForm.paypalEmail} onChange={e => setPayoutForm(f => ({ ...f, paypalEmail: e.target.value }))} placeholder="you@example.com" /></label> : <><label>Account holder<input value={payoutForm.accountHolder} onChange={e => setPayoutForm(f => ({ ...f, accountHolder: e.target.value }))} /></label><label>Bank name<input value={payoutForm.bankName} onChange={e => setPayoutForm(f => ({ ...f, bankName: e.target.value }))} /></label><label>Account / IBAN number<input value={payoutForm.accountNumber} onChange={e => setPayoutForm(f => ({ ...f, accountNumber: e.target.value }))} /></label><label>Routing / SWIFT / IFSC<input value={payoutForm.routingCode} onChange={e => setPayoutForm(f => ({ ...f, routingCode: e.target.value }))} /></label><label>Bank country<input value={payoutForm.country} onChange={e => setPayoutForm(f => ({ ...f, country: e.target.value }))} /></label></>}<button className="lpSave" disabled={saving || availableCents < minimumPayout} onClick={submitWithdrawal}>{saving ? 'Submitting…' : 'Request Withdrawal'}</button>{notice && <div className="lpNotice">{notice}</div>}</div><div className="lpPayoutHistory"><h3>Recent withdrawals</h3>{payouts.length === 0 ? <div className="lpEmpty">No withdrawal requests yet.</div> : payouts.map(row => <div className="lpPayoutRow" key={row.id}><div><strong>${(Number(row.amount_cents || 0) / 100).toFixed(2)}</strong><span>{row.provider === 'bank' ? `Bank${row.bank_name ? ` · ${row.bank_name}` : ''}` : `PayPal${row.paypal_email ? ` · ${row.paypal_email}` : ''}`}</span></div><b className={`lpPayoutStatus ${row.status}`}>{row.status}</b></div>)}</div></section>;
 
-  return <section className="lpPage"><div className="lpHero"><div className="lpAvatarWrap">{profile.avatar_url ? <img src={profile.avatar_url} alt="Profile" /> : <div className="lpAvatarFallback">{(profile.display_name || 'D')[0]?.toUpperCase()}</div>}{creator?.status === 'approved' && <span className="lpVerified"><BadgeCheck size={18} /></span>}</div><h1>{profile.display_name || profile.username || 'Droxion Creator'}</h1><p>{profile.country || 'Global'} · {profile.language || 'English'}{age ? ` · ${age}` : ' · 21+'}</p>{profile.bio && <div className="lpBio">{profile.bio}</div>}{interests.length > 0 && <div className="lpChips">{interests.slice(0, 5).map(item => <span key={item}>{item}</span>)}</div>}</div><div className="lpStats"><button onClick={() => loadNetwork('followers')}><strong>{followers}</strong><span>Followers</span></button><button onClick={() => loadNetwork('following')}><strong>{following}</strong><span>Following</span></button><div><strong>{creator?.status ? creator.status.toUpperCase() : 'VIEWER'}</strong><span>Creator</span></div></div><button className="lpWallet" type="button" onClick={onOpenWallet}><span className="lpIcon"><Coins size={20} /></span><span><strong>{coins} Droxion Coins</strong><small>Buy coins and manage your wallet</small></span><ChevronRight size={20} /></button><div className="lpCreatorCard"><div className="lpCreatorTop"><Sparkles size={19} /><strong>Creator Center</strong></div><div className="lpCreatorNumbers"><div><strong>${(earnings / 100).toFixed(2)}</strong><span>Lifetime earnings</span></div><div><strong>${(availableCents / 100).toFixed(2)}</strong><span>Available balance</span></div></div></div><div className="lpMenu"><button onClick={() => setView('withdraw')}><span className="lpIcon"><Landmark size={20} /></span><span><strong>Withdraw Earnings</strong><small>PayPal or bank transfer</small></span><ChevronRight size={20} /></button><button onClick={() => setView('edit')}><span className="lpIcon"><Edit3 size={20} /></span><span><strong>Edit Profile</strong><small>Name, bio, country, language and interests</small></span><ChevronRight size={20} /></button><button onClick={() => setView('live-settings')}><span className="lpIcon"><Camera size={20} /></span><span><strong>LIVE Settings</strong><small>Test camera, microphone and permissions</small></span><ChevronRight size={20} /></button><button onClick={() => loadNetwork('followers')}><span className="lpIcon"><Users size={20} /></span><span><strong>Followers & Following</strong><small>See your Droxion network</small></span><ChevronRight size={20} /></button><button onClick={() => setView('privacy')}><span className="lpIcon"><ShieldCheck size={20} /></span><span><strong>Safety & Privacy</strong><small>Discovery and interaction permissions</small></span><ChevronRight size={20} /></button><button onClick={() => setView('support')}><span className="lpIcon"><HelpCircle size={20} /></span><span><strong>Help & Support</strong><small>Send a support request</small></span><ChevronRight size={20} /></button><button className="lpLogout" onClick={logout}><span className="lpIcon"><LogOut size={20} /></span><span><strong>Log Out</strong><small>Sign out of this device</small></span><ChevronRight size={20} /></button></div></section>;
+  return <section className="lpPage"><div className="lpHero"><div className="lpAvatarWrap">{profile.avatar_url ? <img src={profile.avatar_url} alt="Profile" /> : <div className="lpAvatarFallback">{(profile.display_name || 'D')[0]?.toUpperCase()}</div>}{creator?.status === 'approved' && <span className="lpVerified"><BadgeCheck size={18} /></span>}</div><h1>{profile.display_name || profile.username || 'Droxion Creator'}</h1><p>{profile.country || 'Global'} · {profile.language || 'English'}{age ? ` · ${age}` : ' · 21+'}</p>{profile.bio && <div className="lpBio">{profile.bio}</div>}{interests.length > 0 && <div className="lpChips">{interests.slice(0, 5).map(item => <span key={item}>{item}</span>)}</div>}</div><div className="lpStats"><button onClick={() => loadNetwork('followers')}><strong>{followers}</strong><span>Followers</span></button><button onClick={() => loadNetwork('following')}><strong>{following}</strong><span>Following</span></button><div><strong>{creator?.status ? creator.status.toUpperCase() : 'VIEWER'}</strong><span>Creator</span></div></div><button className="lpWallet" type="button" onClick={onOpenWallet}><span className="lpIcon"><Coins size={20} /></span><span><strong>{coins} Droxion Coins</strong><small>Buy coins and manage your wallet</small></span><ChevronRight size={20} /></button><div className="lpCreatorCard"><div className="lpCreatorTop"><Sparkles size={19} /><strong>Creator Center</strong></div><div className="lpCreatorNumbers"><div><strong>${(earnings / 100).toFixed(2)}</strong><span>Lifetime earnings</span></div><div><strong>${(availableCents / 100).toFixed(2)}</strong><span>Available balance</span></div></div></div><div className="lpMenu"><span className="publishDeleteAccount profileAccountActionHidden" aria-hidden="true" /><button onClick={() => setView('withdraw')}><span className="lpIcon"><Landmark size={20} /></span><span><strong>Withdraw Earnings</strong><small>PayPal or bank transfer</small></span><ChevronRight size={20} /></button><button onClick={() => setView('edit')}><span className="lpIcon"><Edit3 size={20} /></span><span><strong>Edit Profile</strong><small>Name, bio, country, language and interests</small></span><ChevronRight size={20} /></button><button onClick={() => setView('live-settings')}><span className="lpIcon"><Camera size={20} /></span><span><strong>LIVE Settings</strong><small>Test camera, microphone and permissions</small></span><ChevronRight size={20} /></button><button onClick={() => loadNetwork('followers')}><span className="lpIcon"><Users size={20} /></span><span><strong>Followers & Following</strong><small>See your Droxion network</small></span><ChevronRight size={20} /></button><button onClick={() => setView('privacy')}><span className="lpIcon"><ShieldCheck size={20} /></span><span><strong>Safety & Privacy</strong><small>Discovery and interaction permissions</small></span><ChevronRight size={20} /></button><button onClick={() => setView('support')}><span className="lpIcon"><HelpCircle size={20} /></span><span><strong>Help & Support</strong><small>Send a support request</small></span><ChevronRight size={20} /></button><button className="lpLogout" onClick={logout}><span className="lpIcon"><LogOut size={20} /></span><span><strong>Log Out</strong><small>Sign out of this device</small></span><ChevronRight size={20} /></button></div></section>;
 }

--- a/supabase/migrations/20260819_add_google_play_coin_fulfillment.sql
+++ b/supabase/migrations/20260819_add_google_play_coin_fulfillment.sql
@@ -1,0 +1,104 @@
+alter table public.droxion_products add column if not exists google_product_id text;
+
+create unique index if not exists droxion_products_google_product_id_key
+on public.droxion_products (google_product_id)
+where google_product_id is not null;
+
+create table if not exists public.droxion_google_transactions (
+  purchase_token text primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  order_id text,
+  product_id text not null,
+  package_id text not null,
+  coins integer not null check (coins > 0),
+  purchase_state integer,
+  consumption_state integer,
+  acknowledgement_state integer,
+  purchase_time timestamptz,
+  raw_payload jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+alter table public.droxion_google_transactions enable row level security;
+revoke all on table public.droxion_google_transactions from anon, authenticated;
+grant all on table public.droxion_google_transactions to service_role;
+
+create index if not exists droxion_google_transactions_user_id_idx
+on public.droxion_google_transactions (user_id, created_at desc);
+
+create or replace function public.droxion_fulfill_google_purchase(
+  p_user_id uuid,
+  p_purchase_token text,
+  p_order_id text,
+  p_product_id text,
+  p_package_id text,
+  p_coins integer,
+  p_purchase_state integer,
+  p_consumption_state integer,
+  p_acknowledgement_state integer,
+  p_purchase_time timestamptz,
+  p_raw_payload jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_existing public.droxion_google_transactions%rowtype;
+  v_balance bigint;
+begin
+  if p_user_id is null then raise exception 'User is required.'; end if;
+  if nullif(btrim(p_purchase_token),'') is null then raise exception 'Purchase token is required.'; end if;
+  if nullif(btrim(p_product_id),'') is null then raise exception 'Product ID is required.'; end if;
+  if nullif(btrim(p_package_id),'') is null then raise exception 'Package ID is required.'; end if;
+  if p_coins is null or p_coins <= 0 then raise exception 'Coin amount must be greater than zero.'; end if;
+
+  select * into v_existing
+  from public.droxion_google_transactions
+  where purchase_token = btrim(p_purchase_token)
+  for update;
+
+  if found then
+    if v_existing.user_id <> p_user_id then
+      raise exception 'This Google Play purchase already belongs to another account.';
+    end if;
+    select coin_balance into v_balance from public.droxion_wallets where user_id = p_user_id;
+    return jsonb_build_object('ok', true, 'already_completed', true, 'coins', v_existing.coins, 'coin_balance', coalesce(v_balance, 0));
+  end if;
+
+  insert into public.droxion_wallets(user_id, coin_balance, free_matches_remaining, plan)
+  values(p_user_id, 0, 2, 'free')
+  on conflict(user_id) do nothing;
+
+  update public.droxion_wallets
+  set coin_balance = coin_balance + p_coins,
+      updated_at = now()
+  where user_id = p_user_id
+  returning coin_balance into v_balance;
+
+  insert into public.droxion_google_transactions(
+    purchase_token, user_id, order_id, product_id, package_id, coins,
+    purchase_state, consumption_state, acknowledgement_state, purchase_time, raw_payload
+  ) values (
+    btrim(p_purchase_token), p_user_id, nullif(btrim(coalesce(p_order_id,'')),''), btrim(p_product_id), btrim(p_package_id), p_coins,
+    p_purchase_state, p_consumption_state, p_acknowledgement_state, p_purchase_time, coalesce(p_raw_payload,'{}'::jsonb)
+  );
+
+  insert into public.droxion_wallet_transactions(
+    user_id, amount, transaction_type, balance_after, provider, provider_transaction_id, metadata
+  ) values (
+    p_user_id, p_coins, 'coin_purchase', v_balance, 'google_play', btrim(p_purchase_token),
+    jsonb_build_object('order_id', p_order_id, 'product_id', p_product_id, 'package_id', p_package_id)
+  );
+
+  return jsonb_build_object('ok', true, 'already_completed', false, 'coins', p_coins, 'coin_balance', v_balance);
+end;
+$$;
+
+revoke all on function public.droxion_fulfill_google_purchase(uuid,text,text,text,text,integer,integer,integer,integer,timestamptz,jsonb) from public, anon, authenticated;
+grant execute on function public.droxion_fulfill_google_purchase(uuid,text,text,text,text,integer,integer,integer,integer,timestamptz,jsonb) to service_role;
+
+update public.droxion_products
+set google_product_id = apple_product_id
+where product_type = 'coin_pack' and apple_product_id is not null and google_product_id is null;


### PR DESCRIPTION
## Android launch preparation

This PR prepares Droxion Live for Google Play without changing the existing web/iOS architecture.

### Included
- Native Google Play Billing for Droxion coin packs
- Server-side Android Publisher purchase verification
- Idempotent Google Play wallet fulfillment and purchase ledger
- Server-side consumption after verified fulfillment
- Android API 36 / signed AAB GitHub Actions release workflow
- Camera and microphone permissions for LIVE
- Google Play product mapping and launch documentation
- Tracked Supabase migration for Google Play purchases

### Production database
The Google Play product column, transaction ledger, fulfillment RPC, RLS, and service-role-only permissions have already been applied to the active Droxion Supabase project.

### External setup required before merge/release
- Create/confirm the Play Console app for `com.droxion.live`
- Activate the four Droxion coin products
- Link a Google Cloud service account with Android Publisher access
- Add `GOOGLE_PLAY_SERVICE_ACCOUNT_EMAIL` and `GOOGLE_PLAY_SERVICE_ACCOUNT_PRIVATE_KEY` to Vercel production
- Add Android upload-keystore secrets to GitHub Actions
- Generate the signed AAB and test it through Play Internal testing

This remains a draft until the real Play Billing flow is tested on a physical Android device.